### PR TITLE
Dockerfile: Clean up yum/pip commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,9 @@ COPY ./server/requirements.txt ./
 COPY ./setup.sh ./
 
 RUN yum install -y gnupg curl python3-devel python3-pip nginx && \
-    pip3 install -r requirements.txt && \
+    yum clean all
+
+RUN pip3 install -r requirements.txt && \
     pip3 install gunicorn
 
 COPY --from=build-vue /app/dist /usr/share/nginx/html


### PR DESCRIPTION
Was playing around with building fcct-online and saw some quick fixes for the Dockerfile.
The yum clean step will save a couple of megabytes in the final image.