### PR TITLE
nginx: replace $PORT with 8007

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,4 @@ COPY ./server .
 
 RUN ./setup.sh --container && go build ./main.go
 
-CMD sed -i -e 's/$PORT/'"$PORT"'/g' /etc/nginx/conf.d/default.conf && \
-    nginx && \
-    ./main
+CMD nginx && ./main

--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@
 Pull image from quay.io:
 ```bash
 $ podman pull quay.io/zonggen/fcct-online:latest
-$ podman run -d --rm --name fcct-online -e "PORT=8765" -p 8007:8765 quay.io/zonggen/fcct-online:latest
+$ podman run -d --rm --name fcct-online -p 8007:8007 quay.io/zonggen/fcct-online:latest
 ```
 or build local image:
 ```bash
 $ git clone https://github.com/coreos/fcct-online.git
 $ cd fcct-online/
 $ podman build -t fcct-online:latest .
-$ podman run -d --rm --name fcct-online -e "PORT=8765" -p 8007:8765 fcct-online:latest
+$ podman run -d --rm --name fcct-online -p 8007:8007 fcct-online:latest
 ```
 
 The app is now running on http://localhost:8007/

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,5 +1,5 @@
 server {
-  listen $PORT;
+  listen 8007;
 
   root /usr/share/nginx/html;
   index index.html index.html;


### PR DESCRIPTION
When deploying to openshift cluster locally, the build process
returned error:

`sed: couldn't open temporary file /etc/nginx/conf.d/sedzmzRoa: Permission denied`

So try remove sed and replace the $PORT with constant 8007 to
see if it works.

Signed-off-by: Allen Bai <abai@redhat.com>