### PR TITLE
client: fix acorn vulnerabilities >=5.7.4

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -3478,8 +3478,7 @@
     "acorn": {
       "version": "6.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
-      "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
-      "dev": true
+      "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA=="
     },
     "acorn-walk": {
       "version": "7.1.1",
@@ -14289,9 +14288,9 @@
       }
     },
     "yargs-parser": {
-      "version": "18.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.1.tgz",
-      "integrity": "sha512-KRHEsOM16IX7XuLnMOqImcPNbLVXMNHYAoFc3BKR8Ortl5gzDbtXvvEoGx9imk5E+X1VeNKNlcHr8B8vi+7ipA==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
       "dev": true,
       "requires": {
         "camelcase": "^5.0.0",

--- a/client/package.json
+++ b/client/package.json
@@ -13,7 +13,8 @@
     "bootstrap-vue": "^2.0.0-rc.27",
     "core-js": "^3.6.4",
     "vue": "^2.6.10",
-    "vue-router": "^3.0.3"
+    "vue-router": "^3.0.3",
+    "acorn": ">=5.7.4"
   },
   "devDependencies": {
     "@vue/cli-plugin-babel": "^4.2.3",


### PR DESCRIPTION
Adds "acorn >= 5.7.4" to "dependencies" and runs "npm audit fix"
for other low severity vulnerabilities.

Signed-off-by: Allen Bai <abai@redhat.com>