### PR TITLE
setup.sh: bump fcct version and update signing key

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,6 +1,6 @@
 set -eo pipefail
 
-ver='v0.1.0'
+ver='v0.6.0'
 
 print_help(){
     printf "options:\n\
@@ -11,15 +11,16 @@ print_help(){
 
 setup() {
     set -x
-    rm -f ./fcct-* app-signing-pubkey.gpg
+    rm -f ./fcct-* fedora.gpg
 
     # Download fcct binary and detached signature
     curl -O -L "https://github.com/coreos/fcct/releases/download/${ver}/fcct-x86_64-unknown-linux-gnu"
     curl -O -L "https://github.com/coreos/fcct/releases/download/${ver}/fcct-x86_64-unknown-linux-gnu.asc"
 
-    # Download Coreos Application Signing Key and import it
-    curl -O -L http://coreos.com/dist/pubkeys/app-signing-pubkey.gpg
-    gpg --import app-signing-pubkey.gpg
+    # Download Fedora Signing Keys and import it
+    # https://github.com/coreos/fcct/blob/master/docs/getting-started.md#standalone-binary
+    curl -O -L https://getfedora.org/static/fedora.gpg
+    gpg --import fedora.gpg
 
     # Verify the downloaded binary
     gpg --verify fcct-x86_64-unknown-linux-gnu.asc fcct-x86_64-unknown-linux-gnu


### PR DESCRIPTION
To align with FCCT releases, bump FCCT version to v0.6.0. For details of new features and bug fixes,
please visit https://github.com/coreos/fcct/releases.

Signed-off-by: Allen Bai <abai@redhat.com>